### PR TITLE
Kill shim on offload / load shim on LoadSnapshot 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,8 +278,8 @@ demo-network: install-cni-bins $(FCNET_CONFIG)
 # Firecracker submodule
 ##########################
 .PHONY: firecracker
-firecracker: $(FIRECRACKER_BIN) $(JAILER_BIN)
-
+firecracker:
+	_submodules/firecracker/tools/devtool build --release
 .PHONY: install-firecracker
 install-firecracker: firecracker
 	install -D -o root -g root -m755 -t $(INSTALLROOT)/bin $(FIRECRACKER_BIN)

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -811,24 +811,6 @@ func (s *service) LoadSnapshot(ctx context.Context, req *proto.LoadSnapshotReque
 		return nil, err
 	}
 
-	// Workaround for https://github.com/firecracker-microvm/firecracker/issues/1974
-	patchDriveReq, err := formPatchDriveReq("MN2HE43UOVRDA", s.taskDrivePathOnHost)
-	if err != nil {
-		s.logger.WithError(err).Error("Failed to create patch drive request")
-		return nil, err
-	}
-
-	resp, err = s.httpControlClient.Do(patchDriveReq)
-	if err != nil {
-		s.logger.WithError(err).Error("Failed to send patch drive request")
-		return nil, err
-	}
-	if !strings.Contains(resp.Status, "204") {
-		s.logger.WithError(err).Error("Failed to patch drive")
-		s.logger.WithError(err).Errorf("Status of request: %s", resp.Status)
-		return nil, err
-	}
-
 	return &empty.Empty{}, nil
 }
 
@@ -1637,31 +1619,6 @@ func formCreateSnapReq(snapshotPath, memPath string) (*http.Request, error) {
 		logrus.WithError(err).Error("Failed to create new HTTP request in formCreateSnapReq")
 		return nil, err
 	}
-	req.Header.Add("accept", "application/json")
-	req.Header.Add("Content-Type", "application/json")
-
-	return req, nil
-}
-
-func formPatchDriveReq(driveID, pathOnHost string) (*http.Request, error) {
-	var req *http.Request
-
-	data := map[string]string{
-		"drive_id":     driveID,
-		"path_on_host": pathOnHost,
-	}
-	json, err := json.Marshal(data)
-	if err != nil {
-		logrus.WithError(err).Error("Failed to marshal json data")
-		return nil, err
-	}
-
-	req, err = http.NewRequest("PATCH", fmt.Sprintf("http+unix://firecracker/drives/%s", driveID), bytes.NewBuffer(json))
-	if err != nil {
-		logrus.WithError(err).Error("Failed to create new HTTP request in formPauseReq")
-		return nil, err
-	}
-
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Updated firecracker to [9511525c8d8](https://github.com/firecracker-microvm/firecracker/commit/9511525c8d8abf836a45f922ca69ef18b04efa41). This is right after [#2045](https://github.com/firecracker-microvm/firecracker/pull/2045)
* Kill shim process on offload.
* Add functionality to load the shim.
* Load the shim on LoadSnapshot 

Currently, if LoadSnapshot is called immediately after Offload, an error from containerd that the shim socket address is already in use. For the time being, we offset this by waiting for 10ms between Offload and LoadSnapshot.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
